### PR TITLE
chore: codeowners -> boost

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/boost


### PR DESCRIPTION
This ecosystem-interaction library, primarily used by the CLI, should be reviewed by Boost.