### PR TITLE
feat: upgrade debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Remy Sharp",
   "license": "Apache-2.0",
   "dependencies": {
-    "debug": "^3.1.0",
+    "debug": "^4.1.1",
     "then-fs": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Old version drops support for node 4 and 5, which doesn't
affect us all that much.