### PR TITLE
feat: then-fs -> promise-fs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 module.exports = resolvePkg;
 module.exports.sync = sync;
 
-var fs = require('then-fs');
+var fs = require('promise-fs');
 var path = require('path');
 var debug = require('debug')('snyk:resolve');
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^4.1.1",
-    "then-fs": "^2.0.0"
+    "promise-fs": "^2.1.1"
   },
   "devDependencies": {
     "es6-promise": "^4.2.8",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,7 +31,7 @@ var fs = {
 };
 
 var resolve = proxyquire('../lib/index', {
-  'then-fs': fs,
+  'promise-fs': fs,
 });
 
 test('resolve immediately', function (t) {


### PR DESCRIPTION
`then-fs` seems to be causing a memory leak in `jest` in other tools. It's abandoned, and `graceful-fs` is a drop-in replacement.

Found by https://github.com/facebook/jest/pull/8331